### PR TITLE
add the regression tests

### DIFF
--- a/.github/workflows/ventus-build.yml
+++ b/.github/workflows/ventus-build.yml
@@ -1,0 +1,100 @@
+name: Build VENTUS
+env:
+  LLVM: llvm-project
+  POCL: pocl
+  OCL_ICD: ocl-icd
+  BUILD_TYPE: Release
+  VENTUS_DRIVER: ventus-driver
+  RODINIA: gpu-rodinia
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout SPIKE
+      uses: actions/checkout@v3
+
+    - name: Use Node.js 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+        registry-url: 'https://registry.npmjs.org'
+
+
+    - name: Install Ninja
+      uses: llvm/actions/install-ninja@main
+
+    - name: Install Other needed packages # maybe install llvm release is a better choice
+      run: |
+        sudo apt-get install -y \
+        device-tree-compiler \
+        bsdmainutils \
+        ccache
+
+    - name: Clone needed packages
+      run: |
+        git clone https://github.com/THU-DSP-LAB/llvm-project.git ${{github.workspace}}/../$LLVM
+        git clone https://github.com/THU-DSP-LAB/pocl.git  ${{github.workspace}}/../$POCL
+        git clone https://github.com/OCL-dev/ocl-icd.git ${{github.workspace}}/../$OCL_ICD
+        git clone https://github.com/THU-DSP-LAB/ventus-driver.git ${{github.workspace}}/../$VENTUS_DRIVER
+        git clone https://github.com/Jules-Kong/gpu-rodinia.git ${{github.workspace}}/../$RODINIA
+        export DRIVER_DIR=${{github.workspace}}/../$VENTUS_DRIVER
+        export DRIVER_BUILD_DIR=${DRIVER_DIR}/build
+        export VENTUS_INSTALL_PREFIX=${{github.workspace}}/../$LLVM/install
+        wget -P ${{github.workspace}}/../$RODINIA -c https://www.dropbox.com/s/cc6cozpboht3mtu/rodinia-3.1-data.tar.gz
+        tar -zxvf ${{github.workspace}}/../$RODINIA/rodinia-3.1-data.tar.gz -C ${{github.workspace}}/../$RODINIA
+        mv ${{github.workspace}}/../$RODINIA/rodinia-data/* ${{github.workspace}}/../$RODINIA/data/
+        rm ${{github.workspace}}/../$RODINIA/rodinia-3.1-data.tar.gz
+        rm ${{github.workspace}}/../$RODINIA/rodinia-data -rf
+        cd ${{github.workspace}}/../$LLVM
+
+    - name: Start building llvm-ventus
+      shell: bash
+      run: |
+        bash ${{github.workspace}}/../$LLVM/build-ventus.sh --build llvm
+
+    - name: Start building ocl-icd
+      shell: bash
+      run: |
+        bash ${{github.workspace}}/../$LLVM/build-ventus.sh --build ${OCL_ICD}
+
+    - name: Start building libclc
+      shell: bash
+      run: |
+        bash ${{github.workspace}}/../$LLVM/build-ventus.sh --build libclc
+
+    - name: Start building spike
+      shell: bash
+      run: |
+        bash ${{github.workspace}}/../$LLVM/build-ventus.sh --build spike
+
+    - name: Start building driver
+      shell: bash
+      run: |
+        bash ${{github.workspace}}/../$LLVM/build-ventus.sh --build driver
+
+    - name: Start building pocl
+      shell: bash
+      run: |
+        bash ${{github.workspace}}/../$LLVM/build-ventus.sh --build ${POCL}
+
+    - name: Start testing gpu-rodinia
+      shell: bash
+      run: |
+         bash ${{github.workspace}}/../$LLVM/build-ventus.sh --build rodinia
+
+    - name: Start testing pocl
+      shell: bash
+      run: |
+         bash ${{github.workspace}}/../$LLVM/build-ventus.sh --build test-pocl
+
+    - name: Start ISA simulation test
+      run: |
+        # Later need to add test files and test script for testing
+        echo "Test files and scripts will be added later"


### PR DESCRIPTION
In order to prevent new errors from being introduced when modifying the code, we add regression tests in the project build script and workflow. The regression tests mainly includes some cases that come with gpu-rodinia and pocl.