### PR TITLE
[fix] fix the error that imm would lose their sign bit when do not extend and it is negative

### DIFF
--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -410,7 +410,7 @@ public:
   uint64_t ext_rs3(){ return state.regext_info.valid ? (state.regext_info.ext_rs3<<5) : 0;}
   uint64_t ext_rd(){ return state.regext_info.valid ? (state.regext_info.ext_rd<<5) : 0;}
   int64_t ext_imm(){ return state.regext_info.valid ? ( (state.regext_info.ext_imm) << 58 >> 53) : 0;}
-
+  uint64_t ext_valid() { return state.regext_info.valid;}
 private:
   const isa_parser_t * const isa;
 

--- a/riscv/v_ext_macros.h
+++ b/riscv/v_ext_macros.h
@@ -364,7 +364,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
   type_sew_t<x>::type vs1 = P.VU.elt<type_sew_t<x>::type>(1,rs1_num, i); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(2,rs2_num, i); \
   type_sew_t<x>::type rs1 = (type_sew_t<x>::type)RS1; \
-  type_sew_t<x>::type simm5 = (type_sew_t<x>::type)( (insn.v_simm5() & 31) | p->ext_imm() );
+  type_sew_t<x>::type simm5 = (type_sew_t<x>::type)(p->ext_valid() ? (insn.v_simm5() & 0x1f) | p->ext_imm() : insn.v_simm5()); \
 
 #define VV_U_PARAMS(x) \
   type_usew_t<x>::type &vd = P.VU.elt<type_usew_t<x>::type>(0,rd_num, i, true); \
@@ -393,7 +393,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 
 #define VI_PARAMS(x) \
   type_sew_t<x>::type &vd = P.VU.elt<type_sew_t<x>::type>(0,rd_num, i, true); \
-  type_sew_t<x>::type simm5 = (type_sew_t<x>::type)( (insn.v_simm5() & 31) | p->ext_imm() ); \
+  type_sew_t<x>::type simm5 = (type_sew_t<x>::type)(p->ext_valid() ? (insn.v_simm5() & 0x1f) | p->ext_imm() : insn.v_simm5()); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(2,rs2_num, i);
 
 #define VI12_PARAMS(x) \
@@ -435,7 +435,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(2,rs2_num, i);
 
 #define VI_CMP_PARAMS(x) \
-  type_sew_t<x>::type simm5 = (type_sew_t<x>::type)( (insn.v_simm5() & 31) | p->ext_imm() ); \
+  type_sew_t<x>::type simm5 = (type_sew_t<x>::type)(p->ext_valid() ? (insn.v_simm5() & 0x1f) | p->ext_imm() : insn.v_simm5()); \
   type_sew_t<x>::type vs2 = P.VU.elt<type_sew_t<x>::type>(2,rs2_num, i);
 
 #define VI_XI_SLIDEDOWN_PARAMS(x, off) \
@@ -467,7 +467,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 #define XI_CARRY_PARAMS(x) \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(2,rs2_num, i); \
   auto rs1 = (type_sew_t<x>::type)RS1; \
-  auto simm5 = (type_sew_t<x>::type)( (insn.v_simm5() & 31) | p->ext_imm() ); \
+  auto simm5 = (type_sew_t<x>::type)(p->ext_valid() ? (insn.v_simm5() & 0x1f) | p->ext_imm() : insn.v_simm5()); \
 
 #define VV_CARRY_PARAMS(x) \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(2,rs2_num, i); \
@@ -476,7 +476,7 @@ static inline bool is_aligned(const unsigned val, const unsigned pos)
 #define XI_WITH_CARRY_PARAMS(x) \
   auto vs2 = P.VU.elt<type_sew_t<x>::type>(2,rs2_num, i); \
   auto rs1 = (type_sew_t<x>::type)RS1; \
-  auto simm5 = (type_sew_t<x>::type)( (insn.v_simm5() & 31) | p->ext_imm() ); \
+  auto simm5 = (type_sew_t<x>::type)(p->ext_valid() ? (insn.v_simm5() & 0x1f) | p->ext_imm() : insn.v_simm5()); \
   auto &vd = P.VU.elt<type_sew_t<x>::type>(0,rd_num, i, true);
 
 #define VV_WITH_CARRY_PARAMS(x) \


### PR DESCRIPTION
增加一个状态，用于是否进行立即数扩展的判断，在提取指令中的立即数时，跟据该状态生成相应的立即数。