### PR TITLE
[BUG] Run workgroups one by one

### DIFF
--- a/fesvr/syscall.cc
+++ b/fesvr/syscall.cc
@@ -165,6 +165,7 @@ syscall_t::syscall_t(htif_t* htif)
 
   register_command(0, std::bind(&syscall_t::handle_syscall, this, _1), "syscall");
 
+#if 0
   int stdin_fd = dup(0), stdout_fd0 = dup(1), stdout_fd1 = dup(1);
   if (stdin_fd < 0 || stdout_fd0 < 0 || stdout_fd1 < 0)
     throw std::runtime_error("could not dup stdin/stdout");
@@ -172,6 +173,7 @@ syscall_t::syscall_t(htif_t* htif)
   fds.alloc(stdin_fd); // stdin -> stdin
   fds.alloc(stdout_fd0); // stdout -> stdout
   fds.alloc(stdout_fd1); // stderr -> stdout
+#endif
 }
 
 std::string syscall_t::do_chroot(const char* fn)

--- a/riscv/insns/endprg.h
+++ b/riscv/insns/endprg.h
@@ -1,7 +1,7 @@
 p->get_sim()->modify_reach_end();
 p->gpgpu_unit.w->set_barrier_2(p->get_csr(CSR_WID));
 if(p->get_sim()->get_reach_end()){
-      std::cout<<"all warps reach the endprg. now proc 0 will end the simulation."<<std::endl;
+//      std::cout<<"all warps reach the endprg. now proc 0 will end the simulation."<<std::endl;
       p->get_sim()->append_reach_end();
       //return 0;
     }

--- a/riscv/log_file.h
+++ b/riscv/log_file.h
@@ -19,7 +19,7 @@ public:
     if (!path)
       return;
 
-    wrapped_file.reset(fopen(path, "w"));
+    wrapped_file.reset(fopen(path, "a"));
     if (! wrapped_file) {
       std::ostringstream oss;
       oss << "Failed to open log file at `" << path << "': "

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -1285,6 +1285,7 @@ void warp_schedule_t::parse_gpgpuarch_string(const char *s)
   uint64_t pdssize=0;
   uint64_t pdsbase=0x78000000;
   uint64_t knlbase=0x80000000;
+  uint64_t currwgid=0;
   size_t kernel_size[3]={0,1,1};
 
   while (pos < len) {
@@ -1314,6 +1315,8 @@ void warp_schedule_t::parse_gpgpuarch_string(const char *s)
       pdsbase = get_long_token(str,',',pos);
     else if (attr == "knlbase")
       knlbase = get_long_token(str,',',pos);
+    else if (attr == "currwgid")
+      currwgid = get_long_token(str,',',pos);
     else
       bad_gpgpuarch_string(s, "Unsupported token");
     ++pos;
@@ -1332,6 +1335,7 @@ void warp_schedule_t::parse_gpgpuarch_string(const char *s)
   pds_size = pdssize == 0 ? (numw * numt )<< 10 : pdssize;
   pds_base = pdsbase;
   knl_base = knlbase;
+  curr_wgid = currwgid;
 
   kernel_size[0] =  kernel_size[0]==0 ? (numwg/(kernel_size[1]*kernel_size[2])) : kernel_size[0];
   workgroup_size_x=kernel_size[0];
@@ -1342,7 +1346,9 @@ void warp_schedule_t::parse_gpgpuarch_string(const char *s)
     bad_gpgpuarch_string(s, "kernel size doesn't match total wg size");
   }
 
-  std::cout << std::dec<<"warp number: " << warp_number << " thread number = " << thread_number << "  workgroup number = "<< workgroup_number \
+  /*
+  std::cout << "--- warp number: " << warp_number << " thread number = " << thread_number << "  workgroup number = "<< workgroup_number \
       <<" workgroup dimension:"<<kernel_size[0]<<"*"<<kernel_size[1]<<"*"<<kernel_size[2] \
-      <<std::hex<<" lds size: 0x"<<lds_size<<" pds size: 0x"<<pds_size<<" lds base: 0x"<<lds_base<<" pds base: 0x"<<pds_base<<" knl base: 0x"<<knl_base << std::endl;
+      <<std::hex<<" lds size: "<<lds_size<<" pds size: "<<pds_size<<" lds base: "<<lds_base<<" pds base: "<<pds_base \
+      <<" knl base: "<<knl_base << " current workgroup id: " << curr_wgid << std::endl;*/
 }

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -69,7 +69,7 @@ class warp_schedule_t
     std::vector<int> barriers;
     bool is_all_true;
     int barrier_counter;
-    uint64_t lds_base,lds_size,pds_base,pds_size,knl_base;
+    uint64_t lds_base,lds_size,pds_base,pds_size,knl_base, curr_wgid;
 };
 
 struct insn_desc_t  //mask


### PR DESCRIPTION
- Run workgroups one by one, to avoid allocating memory for all warps one time
- The private memory is temporarily specified to 256MB, 2048 warps in one workgroup can be supported
- Remove make dts files
- Core number in logfile is different, search 'endprg' to distinguish different workgroups
- Remove dup stdin, stdout, stderr to limit max file descriptor
- Should limit the pdssize to 256MB in POCL at the same time