### PR TITLE
[fix] modify kernel address

### DIFF
--- a/gpgpu-testcase/driver/CMakeLists.txt
+++ b/gpgpu-testcase/driver/CMakeLists.txt
@@ -2,12 +2,14 @@ cmake_minimum_required(VERSION 3.21)
 set(PROJECT spike_driver)
 project(${PROJECT})
 
-# Define KERNEL_ADDRESS if not already defined, with a default value of 0x80000098
+# Define KERNEL_ADDRESS if not already defined (default: 0x800000b8)
 if(NOT DEFINED KERNEL_ADDRESS)
-    set(KERNEL_ADDRESS "0x800000b8")
+   message(STATUS "KERNEL_ADDRESS not specified, using default address 0x800000b8")
+   set(KERNEL_ADDRESS "0x800000b8")
+else()
+   message(STATUS "Using specified KERNEL_ADDRESS: ${KERNEL_ADDRESS}") 
 endif()
 
-# Add the KERNEL_ADDRESS definition as a compile-time macro
 add_compile_definitions(KERNEL_ADDRESS=${KERNEL_ADDRESS})
 
 set(CMAKE_CXX_STANDARD 17)
@@ -20,6 +22,8 @@ include_directories($ENV{SPIKE_SRC_DIR}/riscv)
 include_directories($ENV{SPIKE_SRC_DIR}/build)
 include_directories($ENV{SPIKE_SRC_DIR}/softfloat)
 include_directories($ENV{SPIKE_SRC_DIR}/fesvr)
+
+#set(CMAKE_POSITION_INDEPENDENT_CODE True)
 
 file(GLOB_RECURSE SRCS ./ventus.cpp)
 

--- a/gpgpu-testcase/driver/CMakeLists.txt
+++ b/gpgpu-testcase/driver/CMakeLists.txt
@@ -2,8 +2,15 @@ cmake_minimum_required(VERSION 3.21)
 set(PROJECT spike_driver)
 project(${PROJECT})
 
-set(CMAKE_CXX_STANDARD 17)
+# Define KERNEL_ADDRESS if not already defined, with a default value of 0x80000098
+if(NOT DEFINED KERNEL_ADDRESS)
+    set(KERNEL_ADDRESS "0x800000b8")
+endif()
 
+# Add the KERNEL_ADDRESS definition as a compile-time macro
+add_compile_definitions(KERNEL_ADDRESS=${KERNEL_ADDRESS})
+
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS -lstdc++)
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
@@ -14,8 +21,6 @@ include_directories($ENV{SPIKE_SRC_DIR}/build)
 include_directories($ENV{SPIKE_SRC_DIR}/softfloat)
 include_directories($ENV{SPIKE_SRC_DIR}/fesvr)
 
-#set(CMAKE_POSITION_INDEPENDENT_CODE True)
-
 file(GLOB_RECURSE SRCS ./ventus.cpp)
 
 link_directories($ENV{SPIKE_TARGET_DIR}/lib)
@@ -24,10 +29,8 @@ add_library(${PROJECT} SHARED ${SRCS})
 
 target_link_libraries(${PROJECT} PUBLIC spike_main)
 
-
 set_target_properties(${PROJECT} PROPERTIES OUTPUT_NAME "${PROJECT}")
 set_target_properties(${PROJECT} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-
 
 add_executable(spike_test ./test.cpp)
 add_dependencies(spike_test ${PROJECT})

--- a/gpgpu-testcase/driver/test.cpp
+++ b/gpgpu-testcase/driver/test.cpp
@@ -2,6 +2,10 @@
 #include <iostream>
 using namespace std;
 
+#ifndef KERNEL_ADDRESS
+#define KERNEL_ADDRESS  0x800000b8  // need modify 
+#endif
+
 struct meta_data{  // 这个metadata是供驱动使用的，而不是给硬件的
     uint64_t kernel_id;
     uint64_t kernel_size[3];///> 每个kernel的workgroup三维数目
@@ -63,7 +67,7 @@ int main(){
     meta.pdsBaseAddr=pdsbase;
     uint32_t data_2[14];//metadata
     for(int i=0;i<14;i++) data_2[i]=1;
-    data_2[0]=0x800000b8;
+    data_2[0]=KERNEL_ADDRESS;
     data_2[1]=(uint32_t)vaddr_4;
     data_2[2]=meta.kernel_size[0];
     data_2[6]=num_thread;

--- a/gpgpu-testcase/driver/test.cpp
+++ b/gpgpu-testcase/driver/test.cpp
@@ -63,7 +63,7 @@ int main(){
     meta.pdsBaseAddr=pdsbase;
     uint32_t data_2[14];//metadata
     for(int i=0;i<14;i++) data_2[i]=1;
-    data_2[0]=0x80000098;
+    data_2[0]=0x800000b8;
     data_2[1]=(uint32_t)vaddr_4;
     data_2[2]=meta.kernel_size[0];
     data_2[6]=num_thread;


### PR DESCRIPTION
the vectorAdd kernel address is not right, so i fix it.

`riscv64-unknown-elf-objdump -d vecadd.riscv | grep vectorAdd
` 

`800000b8 <vectorAdd>:`