### PR TITLE
Fix double-delete in spike_device and add defensive nulling

### DIFF
--- a/spike_main/spike_device.cc
+++ b/spike_main/spike_device.cc
@@ -198,7 +198,11 @@ spike_device::spike_device():sim(NULL),buffer(),buffer_data(){
 };
 
 spike_device::~spike_device(){
-  delete sim;delete[] srcfilename,logfilename;
+  if (sim != nullptr) {
+    delete sim;
+    sim = nullptr;
+}
+  delete[] srcfilename,logfilename;
   for (auto& mem : buffer_data)
     if(mem.second!=nullptr) {delete mem.second;mem.second=nullptr;}
   const_buffer.clear();
@@ -669,6 +673,7 @@ int spike_device::run(meta_data* knl_data,uint64_t knl_start_pc){
   //    log_path = log_name;
 
       delete sim;
+      sim = nullptr; //Prevent repeated deletes when destructuring
   }
 
   for (auto& plugin_device : plugin_devices)


### PR DESCRIPTION
Description: This patch fixes a double-delete crash observed in the Spike device implementation. The root cause is that the sim simulator object could be deleted inside run() while the destructor later attempted to delete it again, causing a SIGSEGV. The change ensures sim is set to nullptr immediately after deletion and the destructor performs a defensive null check.

Summary of changes:
After deleting sim inside run(), set sim = nullptr.
Ensure destructor only deletes sim if it is non-null and then nulls it.

Why:
Prevents use-after-free / double-delete crashes during simulator shutdown or reset sequences.
Keeps behavioral change minimal and low-risk while maintaining current ownership semantics.
