### PR TITLE
Fix double-delete crash in Spike device by removing duplicate deletion of sim

### DIFF
--- a/spike_main/spike_device.cc
+++ b/spike_main/spike_device.cc
@@ -198,7 +198,7 @@ spike_device::spike_device():sim(NULL),buffer(),buffer_data(){
 };
 
 spike_device::~spike_device(){
-  delete sim;delete[] srcfilename,logfilename;
+  delete[] srcfilename,logfilename;
   for (auto& mem : buffer_data)
     if(mem.second!=nullptr) {delete mem.second;mem.second=nullptr;}
   const_buffer.clear();


### PR DESCRIPTION
Description：This patch fixes a double delete crash observed in Spike device implementations. The cause is that the sim emulator object might be deleted in run() and the destructor later tries to remove it again, resulting in SIGSEGV. This change removes the deletion of the sim in the device's destructor, leaving only the delete function in run().
Why：The root of the problem is unclear ownership: the sim can be deleted in some execution path of run(), and the device destructor also tries to delete the same pointer, resulting in a secondary release and crash (SIGSEGV).
By unifying the deletion logic to run(), we ensure that a single responsible party manages the destruction of the SIM, eliminating race/logic errors for repeated releases.
The fix is more intuitive than nullifying the pointer after the run() function deletes the sim and shorting the pointer detection in the destructor: explicitly "who owns and is responsible for destruction" is safer and easier to maintain than temporary defensive checks.