### PR TITLE
Fix regext validity reset and support explicit GVM start PC

### DIFF
--- a/gvmref/gvmref_interface.cc
+++ b/gvmref/gvmref_interface.cc
@@ -15,6 +15,30 @@ static gvmref_t* ref = nullptr;
 
 namespace {
 
+constexpr uint64_t DEFAULT_START_PC = 0x80000000;
+
+int gvmref_vt_start_with_pc(void* metaData, uint64_t taskID,
+                            uint64_t start_pc) {
+  if(ref->num_workgroup != 0){
+    // 移动 base_wg
+    ref->wg.insert({ref->wg_id_base + ref->num_workgroup, std::make_unique<workgroup_t>(*ref->wg[ref->wg_id_base], true)});
+  }
+  ref->wg_id_base = ref->wg_id_base + ref->num_workgroup;
+  auto knl_data = (gvmref_meta_data *) metaData;
+  ref->num_workgroup = (knl_data->kernel_size[0]) * (knl_data->kernel_size[1]) * (knl_data->kernel_size[2]);
+  ref->num_warp = knl_data->wg_size;
+  auto log_file = std::make_shared<log_file_t>(ref->wg[ref->wg_id_base]->get_logfilename());
+  // 调用拷贝构造函数
+  for (int i = ref->wg_id_base + 1; i < ref->wg_id_base + ref->num_workgroup; i++) {
+    ref->wg.insert({i, std::make_unique<workgroup_t>(*ref->wg[ref->wg_id_base], false)});
+  }
+  for (int i = ref->wg_id_base; i < ref->wg_id_base + ref->num_workgroup; i++) {
+    ref->wg[i]->init_sim(knl_data, start_pc, i - ref->wg_id_base, log_file);
+  }
+  ref->on_kernel_started(ref->wg_id_base, ref->num_workgroup);
+  return 0;
+}
+
 workgroup_t& get_workgroup_or_die(uint32_t software_wg_id) {
   if (ref == nullptr) {
     std::fprintf(stderr, "GVMREF INTERNAL error: reference model is not initialized.\n");
@@ -84,24 +108,12 @@ int gvmref_vt_upload_kernel_file(const char* filename, int taskID) {
   return 0;
 }
 int gvmref_vt_start(void* metaData, uint64_t taskID) {
-  if(ref->num_workgroup != 0){
-    // 移动 base_wg
-    ref->wg.insert({ref->wg_id_base + ref->num_workgroup, std::make_unique<workgroup_t>(*ref->wg[ref->wg_id_base], true)});
-  }
-  ref->wg_id_base = ref->wg_id_base + ref->num_workgroup;
-  auto knl_data = (gvmref_meta_data *) metaData;
-  ref->num_workgroup = (knl_data->kernel_size[0]) * (knl_data->kernel_size[1]) * (knl_data->kernel_size[2]);
-  ref->num_warp = knl_data->wg_size;
-  auto log_file = std::make_shared<log_file_t>(ref->wg[ref->wg_id_base]->get_logfilename());
-  // 调用拷贝构造函数
-  for (int i = ref->wg_id_base + 1; i < ref->wg_id_base + ref->num_workgroup; i++) {
-    ref->wg.insert({i, std::make_unique<workgroup_t>(*ref->wg[ref->wg_id_base], false)});
-  }
-  for (int i = ref->wg_id_base; i < ref->wg_id_base + ref->num_workgroup; i++) {
-    ref->wg[i]->init_sim(knl_data, 0x80000000, i - ref->wg_id_base, log_file);
-  }
-  ref->on_kernel_started(ref->wg_id_base, ref->num_workgroup);
-  return 0;
+  return gvmref_vt_start_with_pc(metaData, taskID, DEFAULT_START_PC);
+}
+
+int gvmref_vt_start_at_pc(void* metaData, uint64_t taskID,
+                          uint64_t start_pc) {
+  return gvmref_vt_start_with_pc(metaData, taskID, start_pc);
 }
 
 int gvmref_vt_kernel_finish() {

--- a/gvmref/gvmref_interface.h
+++ b/gvmref/gvmref_interface.h
@@ -74,6 +74,7 @@ int gvmref_vt_buf_free(uint64_t size, uint64_t *vaddr, uint64_t taskID, uint64_t
 int gvmref_vt_one_buf_free(uint64_t size, uint64_t *vaddr, uint64_t taskID, uint64_t kernelID);
 int gvmref_vt_copy_to_dev(uint64_t dev_vaddr,const void *src_addr, uint64_t size, uint64_t taskID, uint64_t kernelID);
 int gvmref_vt_start(void* metaData, uint64_t taskID);
+int gvmref_vt_start_at_pc(void* metaData, uint64_t taskID, uint64_t start_pc);
 int gvmref_vt_kernel_finish();
 int gvmref_vt_upload_kernel_file(const char* filename, int taskID);
 

--- a/riscv/processor.cc
+++ b/riscv/processor.cc
@@ -200,6 +200,7 @@ void state_t::reset(processor_t* const proc, reg_t max_isa)
   FPR.reset();
   regext_info.ext_imm=0;
   regext_info.valid=0;
+  regext_info.validi=0;
   regext_info.ext_rd=0;
   regext_info.ext_rs1=0;
   regext_info.ext_rs2=0;

--- a/riscv/processor.h
+++ b/riscv/processor.h
@@ -405,6 +405,7 @@ public:
       state.regext_info.ext_rs2 = (imm>>6)&7;
       state.regext_info.ext_rs3 = (imm>>9)&7;
       state.regext_info.ext_imm = 0;
+      state.regext_info.validi = 0;
     }
   }
   void ext_clear(){


### PR DESCRIPTION
## Summary

- clear `regext_info.validi` during processor reset
- clear `validi` when a non-immediate `regext` replaces a prior `regexti`
- add `gvmref_vt_start_at_pc(..., start_pc)` while preserving `gvmref_vt_start(...)` and its existing `0x80000000` default

## Why

The immediate-extension validity bit could survive reset or a transition from
`regexti` to ordinary `regext`. Consumers of `ext_valid()` could therefore treat
a non-immediate extension as if it still carried immediate-extension state.

The GVM reference interface also hard-coded the kernel entry PC inside
`gvmref_vt_start`, preventing callers that already know an executable entry
address from starting the reference model at that address.

## Compatibility

The existing `gvmref_vt_start` symbol and behavior are unchanged. It delegates
to the shared implementation with the original `0x80000000` entry PC.

## Validation

- configured and completed a full `make -j4 all` build
- ran a focused processor-state test covering initialization, `regexti`, transition to ordinary `regext`, and reset
- compiled, linked, and ran a consumer of the new GVMRef API
- verified `libgvmref.so` exports both `gvmref_vt_start` and `gvmref_vt_start_at_pc`
- ran `tests/ventus_extra_stage1_static.py`
- ran `tests/ventus_extra_stage2_static.py`
- ran `git diff --check`
