### PR TITLE
spike: move RT traversal state into RTCore model

### DIFF
--- a/riscv/riscv.mk.in
+++ b/riscv/riscv.mk.in
@@ -26,6 +26,7 @@ riscv_hdrs = \
 	ventus_custom_arith.h \
 	ventus_mma.h \
 	ventus_rt.h \
+	ventus_rtcore_model.h \
 	ventus_custom.h \
 	ventus_shuffle.h \
 	cachesim.h \

--- a/riscv/sim.cc
+++ b/riscv/sim.cc
@@ -493,6 +493,7 @@ const char* sim_t::get_symbol(uint64_t addr)
 
 void sim_t::reset()
 {
+  rtcore_model.resetSm();
   if (dtb_enabled)
     set_rom();
 }

--- a/riscv/sim.h
+++ b/riscv/sim.h
@@ -17,6 +17,7 @@
 #include "log_file.h"
 #include "processor.h"
 #include "simif.h"
+#include "ventus_rtcore_model.h"
 
 #include <fesvr/htif.h>
 #include <fesvr/context.h>
@@ -87,8 +88,12 @@ public:
   }
   void append_reach_end() override{reach_end.push_back(0);current_proc=0;}
   void finish_kernel() override{finish_with_code(1);}
+  ventus_rt::RtCoreModel* get_rtcore_model() override{return &rtcore_model;}
 
 private:
+  // The current functional Spike has no explicit multi-SM placement model, so
+  // all warp processors share one logical SM0 RTCore instance.
+  ventus_rt::RtCoreModel rtcore_model;
   warp_schedule_t w;
   std::vector<uint64_t> reach_end;
   warp_schedule_t *workgroups;

--- a/riscv/simif.h
+++ b/riscv/simif.h
@@ -5,6 +5,10 @@
 
 #include "decode.h"
 
+namespace ventus_rt {
+class RtCoreModel;
+}
+
 // this is the interface to the simulator used by the processors and memory
 class simif_t
 {
@@ -22,6 +26,11 @@ public:
   virtual void modify_reach_end() = 0;
   virtual void append_reach_end() = 0;
   virtual void finish_kernel() = 0;
+
+  // Functional Ventus currently maps one sim_t execution partition to SM0.
+  // Future multi-SM bindings may return the model selected by an explicit SM
+  // identity without changing the instruction/model boundary.
+  virtual ventus_rt::RtCoreModel* get_rtcore_model() { return nullptr; }
 
 };
 

--- a/riscv/ventus_custom.cc
+++ b/riscv/ventus_custom.cc
@@ -1,4 +1,5 @@
 #include "ventus_custom.h"
+#include "ventus_rtcore_model.h"
 
 #include "trap.h"
 #include <array>
@@ -180,17 +181,33 @@ void ventus_exec_rt_traverse(processor_t *p, insn_t insn)
   const reg_t vl = p->VU.vl->read();
   const reg_t vd_num = insn.rd();
   const reg_t vs2_num = insn.rs2();
+  ventus_rt::RtCoreModel *model = p->get_sim()->get_rtcore_model();
+  if (model == nullptr)
+    throw trap_illegal_instruction(insn.bits());
 
+  ventus_rt::LegacyWarpIssue issue;
+  issue.active_mask =
+      static_cast<uint32_t>(p->gpgpu_unit.simt_stack.get_mask());
+  issue.first_lane = static_cast<uint32_t>(p->VU.vstart->read());
+  issue.lane_count = static_cast<uint32_t>(vl);
   for (reg_t lane = p->VU.vstart->read(); lane < vl; ++lane) {
     if (!lane_active(p, lane))
       continue;
+    issue.lane_slots[lane] = p->VU.elt<uint32_t>(2, vs2_num, lane);
+  }
 
-    auto mem = ventus_rt::make_hybrid_memory(
-        *p->get_mmu(), p->get_csr(CSR_PDS), p->get_csr(CSR_NUMW),
-        p->get_csr(CSR_NUMT), p->get_csr(CSR_TID), lane);
-    const reg_t slot = p->VU.elt<uint32_t>(2, vs2_num, lane);
-    const uint32_t status = ventus_rt::traverse(mem, slot);
-    p->VU.elt<uint32_t>(0, vd_num, lane, true) = status;
+  const ventus_rt::LegacyWarpResult result = model->executeLegacyTraverse(
+      issue, [p](uint32_t lane) {
+        return ventus_rt::make_hybrid_memory(
+            *p->get_mmu(), p->get_csr(CSR_PDS), p->get_csr(CSR_NUMW),
+            p->get_csr(CSR_NUMT), p->get_csr(CSR_TID), lane);
+      });
+
+  for (reg_t lane = p->VU.vstart->read(); lane < vl; ++lane) {
+    const uint32_t lane_bit = uint32_t{1} << lane;
+    if ((result.valid_mask & lane_bit) == 0)
+      continue;
+    p->VU.elt<uint32_t>(0, vd_num, lane, true) = result.lane_status[lane];
   }
 
   p->VU.vstart->write(0);
@@ -202,17 +219,26 @@ void ventus_exec_rt_release(processor_t *p, insn_t insn)
 
   const reg_t vl = p->VU.vl->read();
   const reg_t vs2_num = insn.rs2();
+  ventus_rt::RtCoreModel *model = p->get_sim()->get_rtcore_model();
+  if (model == nullptr)
+    throw trap_illegal_instruction(insn.bits());
 
+  ventus_rt::LegacyWarpIssue issue;
+  issue.active_mask =
+      static_cast<uint32_t>(p->gpgpu_unit.simt_stack.get_mask());
+  issue.first_lane = static_cast<uint32_t>(p->VU.vstart->read());
+  issue.lane_count = static_cast<uint32_t>(vl);
   for (reg_t lane = p->VU.vstart->read(); lane < vl; ++lane) {
     if (!lane_active(p, lane))
       continue;
+    issue.lane_slots[lane] = p->VU.elt<uint32_t>(2, vs2_num, lane);
+  }
 
-    auto mem = ventus_rt::make_hybrid_memory(
+  model->executeLegacyRelease(issue, [p](uint32_t lane) {
+    return ventus_rt::make_hybrid_memory(
         *p->get_mmu(), p->get_csr(CSR_PDS), p->get_csr(CSR_NUMW),
         p->get_csr(CSR_NUMT), p->get_csr(CSR_TID), lane);
-    const reg_t slot = p->VU.elt<uint32_t>(2, vs2_num, lane);
-    ventus_rt::release(mem, slot);
-  }
+  });
 
   p->VU.vstart->write(0);
 }

--- a/riscv/ventus_rt.h
+++ b/riscv/ventus_rt.h
@@ -8,6 +8,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
+#include <unordered_map>
 #include <vector>
 
 #ifndef VENTUS_RT_STANDALONE
@@ -22,7 +23,7 @@ namespace ventus_rt {
 
 constexpr reg_t lanes = 32;
 constexpr reg_t rt_pds_base_bytes = 4096;
-constexpr reg_t rt_region_size_bytes = 1008;
+constexpr reg_t rt_region_size_bytes = 384;
 constexpr reg_t rt_total_size_bytes = rt_pds_base_bytes + rt_region_size_bytes;
 
 constexpr reg_t slot_status = 0;
@@ -49,7 +50,13 @@ constexpr reg_t slot_launch_id_x = 20;
 constexpr reg_t slot_launch_id_y = 21;
 constexpr reg_t slot_launch_id_z = 22;
 
-constexpr reg_t control_base = 96;
+constexpr reg_t cps_header_base = 96;
+constexpr reg_t cps_frame_base = 0;
+constexpr reg_t cps_active_level = 1;
+constexpr reg_t cps_fragment_id = 2;
+constexpr reg_t cps_flags = 3;
+
+constexpr reg_t control_base = 112;
 constexpr reg_t control_done = 0;
 constexpr reg_t control_incomplete = 1;
 constexpr reg_t control_accept_hit = 2;
@@ -57,10 +64,9 @@ constexpr reg_t control_ignore_hit = 3;
 constexpr reg_t control_terminate_ray = 4;
 constexpr reg_t control_skip_closest_hit = 5;
 
-constexpr reg_t committed_hit_record_base = 208;
-constexpr reg_t candidate_hit_record_base = 128;
-constexpr reg_t hit_attrib_base = 288;
-constexpr reg_t continuation_base = 368;
+constexpr reg_t committed_hit_record_base = 224;
+constexpr reg_t candidate_hit_record_base = 144;
+constexpr reg_t hit_attrib_base = 304;
 constexpr reg_t hit_record_status = 0;
 constexpr reg_t hit_record_hit_t = 1;
 constexpr reg_t hit_record_sbt_index = 2;
@@ -604,6 +610,7 @@ inline float current_tmax(Memory &mem, reg_t slot)
   return bit_cast_f32(load_word(mem, slot, 0, slot_tmax));
 }
 
+#if 0 /* Superseded v1 PDS-resident traversal continuation. */
 template <typename Memory>
 inline void clear_continuation(Memory &mem, reg_t slot)
 {
@@ -896,6 +903,7 @@ inline bool pop_continuation_entry(Memory &mem, reg_t slot, uint32_t &count,
   store_word(mem, slot, continuation_base, continuation_stack_count, count);
   return true;
 }
+#endif
 
 
 inline uint32_t node_ref_type(uint32_t ref)
@@ -986,13 +994,26 @@ struct ChildHit {
   float t_near = 0.0f;
 };
 
+inline void sort_child_hits(ChildHit (&hits)[4], uint32_t hit_count)
+{
+  for (uint32_t i = 1; i < hit_count; ++i) {
+    const ChildHit hit = hits[i];
+    uint32_t j = i;
+    while (j > 0 && hit.t_near < hits[j - 1].t_near) {
+      hits[j] = hits[j - 1];
+      --j;
+    }
+    hits[j] = hit;
+  }
+}
+
 /*
  * Legacy one-shot tracing path.
  *
- * Current vt.rt.traverse execution enters traverse() and dispatches to the
- * *_cont functions below.  Those continuation paths persist traversal state in
- * scratch so that any-hit/intersection callbacks can accept, ignore, terminate,
- * and then resume traversal.
+ * Current vt.rt.traverse execution uses the private-RTcore context model below.
+ * It keeps paused traversal state out of the shader-visible scratch ABI so an
+ * any-hit/intersection callback can accept, ignore, or terminate before the
+ * same walk resumes.
  *
  * The functions in this disabled block predate that continuation model.  They
  * either traverse to completion with a local stack or pause at a candidate
@@ -1208,8 +1229,7 @@ inline uint32_t trace_vtas(Memory &mem, reg_t slot, const Ray &ray,
           hits[hit_count++] = {child, t_near};
         }
       }
-      std::sort(hits, hits + hit_count,
-                [](const ChildHit &a, const ChildHit &b) { return a.t_near < b.t_near; });
+      sort_child_hits(hits, hit_count);
       for (uint32_t i = hit_count; i > 0; i--)
         stack.push_back({entry.as_base, hits[i - 1].ref, entry.ray,
                          entry.instance_id, entry.instance_sbt_offset,
@@ -1407,6 +1427,7 @@ inline uint32_t trace_aabb_list(Memory &mem, reg_t slot, const Ray &ray,
 }
 #endif
 
+#if 0 /* Superseded v1 PDS-resident traversal paths. */
 template <typename Memory>
 inline uint32_t trace_triangle_list_cont(Memory &mem, reg_t slot,
                                          const Ray &ray, const Scene &scene)
@@ -1550,10 +1571,7 @@ inline uint32_t trace_vtas_cont(Memory &mem, reg_t slot, const Ray &ray,
           hits[hit_count++] = {child, t_near};
       }
 
-      std::sort(hits, hits + hit_count,
-                [](const ChildHit &a, const ChildHit &b) {
-                  return a.t_near < b.t_near;
-                });
+      sort_child_hits(hits, hit_count);
       for (uint32_t i = hit_count; i > 0; i--) {
         TraversalEntry child = {entry.as_base, hits[i - 1].ref, entry.ray,
                                 entry.instance_id,
@@ -1703,6 +1721,363 @@ inline void release(Memory &mem, reg_t slot)
   clear_control(mem, slot);
   clear_continuation(mem, slot);
 }
+#endif
+
+struct TraversalEntry {
+  uint64_t as_base = 0;
+  uint32_t node_ref = invalid_node_ref;
+  Ray ray;
+  uint32_t instance_id = 0;
+  uint32_t instance_sbt_offset = 0;
+  uint64_t instance_addr = 0;
+};
+
+template <typename Memory>
+inline void commit_hit(Memory &mem, reg_t slot, const Scene &scene,
+                       const Hit &hit)
+{
+  write_hit_record(mem, slot, committed_hit_record_base, scene, hit,
+                   rt_status_hit);
+  write_hit_attrib(mem, slot, hit);
+  store_word(mem, slot, 0, slot_hit_t, bit_cast_u32(hit.t));
+  store_word(mem, slot, 0, slot_sbt_index,
+             hit.tri.instance_sbt_record_offset + hit.tri.sbt_index +
+                 load_word(mem, slot, 0, slot_sbt_offset));
+  store_word(mem, slot, 0, slot_status, rt_status_hit);
+}
+
+enum class RtPrivateTraversalKind : uint8_t {
+  triangle_list,
+  aabb_list,
+  vtas,
+};
+
+struct RtPrivateContext {
+  RtPrivateTraversalKind kind;
+  Ray ray;
+  Scene scene;
+  uint32_t next_primitive = 0;
+  std::vector<TraversalEntry> stack;
+};
+
+template <typename Memory>
+inline auto rt_context_key(Memory &mem, reg_t slot, int)
+    -> decltype(mem.rt_context_key(slot))
+{
+  return mem.rt_context_key(slot);
+}
+
+template <typename Memory>
+inline uint64_t rt_context_key(Memory &mem, reg_t slot, long)
+{
+  return uint64_t(reinterpret_cast<uintptr_t>(&mem)) ^ (uint64_t(slot) << 1);
+}
+
+class RtPrivateState {
+public:
+  using ContextMap = std::unordered_map<uint64_t, RtPrivateContext>;
+
+  ContextMap &contexts() { return contexts_; }
+  const ContextMap &contexts() const { return contexts_; }
+  size_t context_count() const { return contexts_.size(); }
+  void reset() { contexts_.clear(); }
+
+private:
+  // Production ownership is one RtCoreModel instance per logical SM.  The
+  // standalone two-argument helpers below exist only for header-level tests.
+  ContextMap contexts_;
+};
+
+template <typename Memory>
+inline void commit_private_candidate(Memory &mem, reg_t slot)
+{
+  const float hit_t = bit_cast_f32(load_word(mem, slot,
+                                             candidate_hit_record_base,
+                                             hit_record_hit_t));
+  const Ray ray = load_ray(mem, slot);
+  if (hit_t >= ray.tmin && hit_t <= current_tmax(mem, slot)) {
+    copy_hit_record(mem, slot, committed_hit_record_base,
+                    candidate_hit_record_base);
+    store_word(mem, slot, 0, slot_hit_t, bit_cast_u32(hit_t));
+    store_word(mem, slot, 0, slot_sbt_index,
+               load_word(mem, slot, candidate_hit_record_base,
+                         hit_record_sbt_index));
+    store_word(mem, slot, 0, slot_status, rt_status_hit);
+  }
+}
+
+template <typename Memory>
+inline uint32_t finish_private_traversal(Memory &mem, reg_t slot,
+                                         uint64_t key,
+                                         RtPrivateState &private_state)
+{
+  store_word(mem, slot, control_base, control_done, 1);
+  const bool hit = committed_hit_valid(mem, slot);
+  store_word(mem, slot, 0, slot_status, hit ? rt_status_hit : rt_status_miss);
+  if (!hit)
+    store_word(mem, slot, committed_hit_record_base, hit_record_status, 0);
+  private_state.contexts().erase(key);
+  return hit ? traversal_complete_hit : traversal_complete_miss;
+}
+
+template <typename Memory>
+inline uint32_t pause_private_candidate(Memory &mem, reg_t slot,
+                                        const Scene &scene,
+                                        const Hit &candidate,
+                                        uint32_t status)
+{
+  write_hit_record(mem, slot, candidate_hit_record_base, scene, candidate,
+                   rt_status_hit);
+  write_hit_attrib(mem, slot, candidate);
+  store_word(mem, slot, control_base, control_incomplete, 1);
+  store_word(mem, slot, 0, slot_status, rt_status_hit);
+  return status;
+}
+
+template <typename Memory>
+inline uint32_t trace_private_triangle_list(Memory &mem, reg_t slot,
+                                            uint64_t key,
+                                            RtPrivateState &private_state)
+{
+  RtPrivateContext &ctx = private_state.contexts().at(key);
+  for (uint32_t i = ctx.next_primitive; i < ctx.scene.primitive_count; ++i) {
+    ctx.next_primitive = i + 1;
+    Ray ray = ctx.ray;
+    ray.tmax = current_tmax(mem, slot);
+    const Triangle tri =
+        load_triangle(mem, ctx.scene.primitive_addr + i * ctx.scene.primitive_stride);
+    Hit candidate;
+    candidate.t = ray.tmax;
+    if (!intersect_triangle(ray, tri, candidate))
+      continue;
+
+    const bool force_opaque = (ray.flags & ray_flag_force_opaque) != 0;
+    const bool force_non_opaque = (ray.flags & ray_flag_force_non_opaque) != 0;
+    const bool opaque = force_opaque || (!force_non_opaque && tri.opaque != 0);
+    if (!opaque)
+      return pause_private_candidate(mem, slot, ctx.scene, candidate,
+                                     traversal_candidate_non_opaque_triangle);
+
+    commit_hit(mem, slot, ctx.scene, candidate);
+    if (ray.flags & ray_flag_terminate_on_first_hit)
+      return finish_private_traversal(mem, slot, key, private_state);
+  }
+  return finish_private_traversal(mem, slot, key, private_state);
+}
+
+template <typename Memory>
+inline uint32_t trace_private_aabb_list(Memory &mem, reg_t slot,
+                                        uint64_t key,
+                                        RtPrivateState &private_state)
+{
+  RtPrivateContext &ctx = private_state.contexts().at(key);
+  for (uint32_t i = ctx.next_primitive; i < ctx.scene.primitive_count; ++i) {
+    ctx.next_primitive = i + 1;
+    Ray ray = ctx.ray;
+    ray.tmax = current_tmax(mem, slot);
+    const ProceduralAabb aabb =
+        load_aabb(mem, ctx.scene.primitive_addr + i * ctx.scene.primitive_stride);
+    float hit_t = 0.0f;
+    if (!intersect_aabb(ray, aabb, hit_t))
+      continue;
+    return pause_private_candidate(mem, slot, ctx.scene,
+                                   hit_from_aabb(aabb, hit_t),
+                                   traversal_candidate_procedural_aabb);
+  }
+  return finish_private_traversal(mem, slot, key, private_state);
+}
+
+template <typename Memory>
+inline uint32_t trace_private_vtas(Memory &mem, reg_t slot, uint64_t key,
+                                   RtPrivateState &private_state)
+{
+  RtPrivateContext &ctx = private_state.contexts().at(key);
+  while (!ctx.stack.empty()) {
+    TraversalEntry entry = ctx.stack.back();
+    ctx.stack.pop_back();
+    if (entry.node_ref == invalid_node_ref)
+      continue;
+
+    entry.ray.tmax = current_tmax(mem, slot);
+    const uint32_t type = node_ref_type(entry.node_ref);
+    const reg_t node_addr = entry.as_base + node_ref_offset(entry.node_ref);
+
+    if (type == node_box4) {
+      ChildHit hits[4];
+      uint32_t hit_count = 0;
+      for (uint32_t i = 0; i < 4; ++i) {
+        const uint32_t child = mem.load32(node_addr + box4_child_ref + i * 4);
+        if (child == invalid_node_ref)
+          continue;
+        float t_near = 0.0f;
+        if (intersect_box4_child(mem, entry.as_base, entry.node_ref, i,
+                                 entry.ray, t_near))
+          hits[hit_count++] = {child, t_near};
+      }
+      sort_child_hits(hits, hit_count);
+      for (uint32_t i = hit_count; i > 0; --i)
+        ctx.stack.push_back({entry.as_base, hits[i - 1].ref, entry.ray,
+                             entry.instance_id, entry.instance_sbt_offset,
+                             entry.instance_addr});
+      continue;
+    }
+
+    if (type == node_instance) {
+      const uint32_t mask = mem.load32(node_addr + instance_mask);
+      if ((entry.ray.cull_mask & mask) == 0)
+        continue;
+      const uint64_t blas = load_u64(mem, node_addr + instance_blas_addr_lo);
+      if (!blas || mem.load32(blas + as_header_magic) != as_magic ||
+          mem.load32(blas + as_header_type) != as_type_blas)
+        continue;
+      Ray object_ray = entry.ray;
+      object_ray.origin = transform_instance_point(
+          mem, node_addr + instance_world_to_object, entry.ray.origin);
+      object_ray.direction = transform_instance_vector(
+          mem, node_addr + instance_world_to_object, entry.ray.direction);
+      ctx.stack.push_back({blas, load_node_ref(mem, blas), object_ray,
+                           mem.load32(node_addr + instance_instance_id),
+                           mem.load32(node_addr + instance_sbt_record_offset),
+                           node_addr});
+      continue;
+    }
+
+    if (type != node_triangle)
+      continue;
+    const Triangle tri = load_vtas_triangle(mem, entry.as_base, entry.node_ref,
+                                             entry.instance_id,
+                                             entry.instance_sbt_offset,
+                                             entry.instance_addr);
+    Hit candidate;
+    candidate.t = entry.ray.tmax;
+    if (!intersect_triangle(entry.ray, tri, candidate))
+      continue;
+    const bool force_opaque = (entry.ray.flags & ray_flag_force_opaque) != 0;
+    const bool force_non_opaque = (entry.ray.flags & ray_flag_force_non_opaque) != 0;
+    const bool opaque = force_opaque || (!force_non_opaque && tri.opaque != 0);
+    if (!opaque)
+      return pause_private_candidate(mem, slot, ctx.scene, candidate,
+                                     traversal_candidate_non_opaque_triangle);
+    commit_hit(mem, slot, ctx.scene, candidate);
+    if (entry.ray.flags & ray_flag_terminate_on_first_hit)
+      return finish_private_traversal(mem, slot, key, private_state);
+  }
+  return finish_private_traversal(mem, slot, key, private_state);
+}
+
+template <typename Memory>
+inline uint32_t traverse(Memory &mem, reg_t slot,
+                         RtPrivateState &private_state)
+{
+  const uint64_t key = rt_context_key(mem, slot, 0);
+  std::unordered_map<uint64_t, RtPrivateContext> &contexts =
+      private_state.contexts();
+  auto it = contexts.find(key);
+  if (it != contexts.end()) {
+    const bool accept = load_word(mem, slot, control_base, control_accept_hit) != 0;
+    const bool terminate = load_word(mem, slot, control_base,
+                                     control_terminate_ray) != 0;
+    if (accept)
+      commit_private_candidate(mem, slot);
+    if (terminate) {
+      clear_control(mem, slot);
+      store_word(mem, slot, control_base, control_done, 1);
+      const bool hit = committed_hit_valid(mem, slot);
+      store_word(mem, slot, 0, slot_status,
+                 hit ? rt_status_hit : rt_status_done);
+      contexts.erase(it);
+      return hit ? traversal_complete_hit : traversal_terminated;
+    }
+    store_word(mem, slot, candidate_hit_record_base, hit_record_status, 0);
+    clear_control(mem, slot);
+    switch (it->second.kind) {
+    case RtPrivateTraversalKind::triangle_list:
+      return trace_private_triangle_list(mem, slot, key, private_state);
+    case RtPrivateTraversalKind::aabb_list:
+      return trace_private_aabb_list(mem, slot, key, private_state);
+    case RtPrivateTraversalKind::vtas:
+      return trace_private_vtas(mem, slot, key, private_state);
+    }
+  }
+
+  clear_control(mem, slot);
+  store_word(mem, slot, candidate_hit_record_base, hit_record_status, 0);
+  store_word(mem, slot, committed_hit_record_base, hit_record_status, 0);
+  const Ray ray = load_ray(mem, slot);
+  const uint64_t accel_addr = load_accel_addr(mem, slot);
+  if (accel_addr == 0)
+    return finish_private_traversal(mem, slot, key, private_state);
+
+  if (mem.load32(accel_addr + 0) == as_magic) {
+    if ((mem.load32(accel_addr + as_header_version) & 0xffffu) != as_version ||
+        mem.load32(accel_addr + as_header_type) != as_type_tlas)
+      return finish_private_traversal(mem, slot, key, private_state);
+    RtPrivateContext ctx = {};
+    ctx.kind = RtPrivateTraversalKind::vtas;
+    ctx.ray = ray;
+    ctx.scene.hit_sbt_base = 0;
+    ctx.scene.shader_group_handle_size = 32;
+    ctx.stack.push_back({accel_addr, load_node_ref(mem, accel_addr), ray, 0, 0, 0});
+    contexts.emplace(key, std::move(ctx));
+    return trace_private_vtas(mem, slot, key, private_state);
+  }
+
+  Scene scene;
+  const uint32_t magic = mem.load32(accel_addr + 0);
+  const uint32_t version = mem.load32(accel_addr + 4);
+  const uint32_t geometry_type = mem.load32(accel_addr + 8);
+  scene.primitive_count = mem.load32(accel_addr + 12);
+  scene.primitive_addr = load_u64(mem, accel_addr + 16);
+  scene.primitive_stride = mem.load32(accel_addr + 24);
+  scene.hit_sbt_base = load_u64(mem, accel_addr + 28);
+  scene.shader_group_handle_size = mem.load32(accel_addr + 36);
+  if (magic != bvh_magic || version != bvh_version ||
+      scene.primitive_count == 0 || scene.primitive_addr == 0 ||
+      scene.primitive_stride == 0)
+    return finish_private_traversal(mem, slot, key, private_state);
+
+  RtPrivateContext ctx = {};
+  ctx.ray = ray;
+  ctx.scene = scene;
+  ctx.kind = geometry_type == geometry_triangle_list
+                 ? RtPrivateTraversalKind::triangle_list
+                 : RtPrivateTraversalKind::aabb_list;
+  if (geometry_type != geometry_triangle_list &&
+      geometry_type != geometry_procedural_aabb_list)
+    return finish_private_traversal(mem, slot, key, private_state);
+  contexts.emplace(key, std::move(ctx));
+  return geometry_type == geometry_triangle_list
+             ? trace_private_triangle_list(mem, slot, key, private_state)
+             : trace_private_aabb_list(mem, slot, key, private_state);
+}
+
+template <typename Memory>
+inline void release(Memory &mem, reg_t slot, RtPrivateState &private_state)
+{
+  private_state.contexts().erase(rt_context_key(mem, slot, 0));
+  clear_control(mem, slot);
+}
+
+#ifdef VENTUS_RT_STANDALONE
+template <typename Memory>
+inline RtPrivateState &standalone_rt_private_state()
+{
+  static RtPrivateState private_state;
+  return private_state;
+}
+
+template <typename Memory>
+inline uint32_t traverse(Memory &mem, reg_t slot)
+{
+  return traverse(mem, slot, standalone_rt_private_state<Memory>());
+}
+
+template <typename Memory>
+inline void release(Memory &mem, reg_t slot)
+{
+  release(mem, slot, standalone_rt_private_state<Memory>());
+}
+#endif
 
 #ifndef VENTUS_RT_STANDALONE
 struct SpikePdsMemory {
@@ -1747,6 +2122,11 @@ struct RawMemory {
 struct HybridMemory {
   SpikePdsMemory slot;
   RawMemory raw;
+
+  uint64_t rt_context_key(reg_t logical_slot) const
+  {
+    return slot.pds_addr(logical_slot);
+  }
 
   uint32_t load32(reg_t addr)
   {

--- a/riscv/ventus_rtcore_model.h
+++ b/riscv/ventus_rtcore_model.h
@@ -1,0 +1,186 @@
+#ifndef RISCV_VENTUS_RTCORE_MODEL_H
+#define RISCV_VENTUS_RTCORE_MODEL_H
+
+#include "ventus_rt.h"
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+#include <utility>
+
+namespace ventus_rt {
+
+// Transitional command accepted by the P1 compatibility boundary.  The slot
+// values and their interpretation remain the legacy shader-visible PDS ABI;
+// they are deliberately not named handoff addresses.
+struct LegacyWarpIssue {
+  uint32_t active_mask = 0;
+  uint32_t first_lane = 0;
+  uint32_t lane_count = 0;
+  std::array<reg_t, lanes> lane_slots{};
+};
+
+struct LegacyWarpResult {
+  uint32_t valid_mask = 0;
+  std::array<uint32_t, lanes> lane_status{};
+};
+
+struct RtCoreDebugSnapshot {
+  uint64_t sm_generation = 1;
+  uint64_t traverse_issue_count = 0;
+  uint64_t release_issue_count = 0;
+  uint64_t private_context_count = 0;
+  bool command_active = false;
+};
+
+// The only place where the P1 model may interpret the legacy PDS contract.
+// A later native handoff adapter replaces this class without changing the
+// SM-owned model/instruction boundary established by this phase.
+class LegacyPdsAdapter {
+public:
+  template <typename MemoryFactory>
+  static LegacyWarpResult traverse(RtPrivateState &private_state,
+                                   const LegacyWarpIssue &issue,
+                                   MemoryFactory &&make_memory)
+  {
+    LegacyWarpResult result;
+    const uint32_t mask = effective_mask(issue);
+
+    for (uint32_t lane = 0; lane < issue.lane_count; ++lane) {
+      const uint32_t lane_bit = uint32_t{1} << lane;
+      if ((mask & lane_bit) == 0)
+        continue;
+
+      auto memory = make_memory(lane);
+      result.lane_status[lane] =
+          ventus_rt::traverse(memory, issue.lane_slots[lane], private_state);
+      result.valid_mask |= lane_bit;
+    }
+
+    return result;
+  }
+
+  template <typename MemoryFactory>
+  static uint32_t release(RtPrivateState &private_state,
+                          const LegacyWarpIssue &issue,
+                          MemoryFactory &&make_memory)
+  {
+    const uint32_t mask = effective_mask(issue);
+
+    for (uint32_t lane = 0; lane < issue.lane_count; ++lane) {
+      const uint32_t lane_bit = uint32_t{1} << lane;
+      if ((mask & lane_bit) == 0)
+        continue;
+
+      auto memory = make_memory(lane);
+      ventus_rt::release(memory, issue.lane_slots[lane], private_state);
+    }
+
+    return mask;
+  }
+
+private:
+  static uint32_t effective_mask(const LegacyWarpIssue &issue)
+  {
+    if (issue.lane_count > lanes)
+      throw std::invalid_argument("legacy RT warp lane count exceeds 32");
+
+    const uint32_t lane_limit =
+        issue.lane_count == lanes
+            ? ~uint32_t{0}
+            : (issue.lane_count == 0
+                   ? uint32_t{0}
+                   : (uint32_t{1} << issue.lane_count) - uint32_t{1});
+    const uint32_t first_lane_mask =
+        issue.first_lane >= lanes
+            ? ~uint32_t{0}
+            : (issue.first_lane == 0
+                   ? uint32_t{0}
+                   : (uint32_t{1} << issue.first_lane) - uint32_t{1});
+    return issue.active_mask & lane_limit & ~first_lane_mask;
+  }
+};
+
+// One instance is owned by one functional Spike execution partition (SM0 in
+// the current single-partition mapping).  P1 also owns the compatibility
+// traversal cursor/frontier/stack so it cannot leak through a template-static
+// global.  Legacy trace input, candidate/committed records, and control words
+// remain in PDS until the native identity/lifecycle model replaces the adapter.
+class RtCoreModel {
+public:
+  template <typename MemoryFactory>
+  LegacyWarpResult executeLegacyTraverse(const LegacyWarpIssue &issue,
+                                         MemoryFactory &&make_memory)
+  {
+    CommandScope command(*this);
+    LegacyWarpResult result = LegacyPdsAdapter::traverse(
+        private_state_, issue, std::forward<MemoryFactory>(make_memory));
+    ++traverse_issue_count_;
+    return result;
+  }
+
+  template <typename MemoryFactory>
+  uint32_t executeLegacyRelease(const LegacyWarpIssue &issue,
+                                MemoryFactory &&make_memory)
+  {
+    CommandScope command(*this);
+    const uint32_t released_mask = LegacyPdsAdapter::release(
+        private_state_, issue, std::forward<MemoryFactory>(make_memory));
+    ++release_issue_count_;
+    return released_mask;
+  }
+
+  void resetSm()
+  {
+    if (command_active_)
+      throw std::logic_error("cannot reset an active RTCore model command");
+
+    ++sm_generation_;
+    traverse_issue_count_ = 0;
+    release_issue_count_ = 0;
+    private_state_.reset();
+  }
+
+  RtCoreDebugSnapshot debugSnapshot() const
+  {
+    return {
+        sm_generation_,
+        traverse_issue_count_,
+        release_issue_count_,
+        private_state_.context_count(),
+        command_active_,
+    };
+  }
+
+private:
+  class CommandScope {
+  public:
+    explicit CommandScope(RtCoreModel &model) : model_(model)
+    {
+      if (model_.command_active_)
+        throw std::logic_error("RTCore model command re-entry");
+      model_.command_active_ = true;
+    }
+
+    ~CommandScope()
+    {
+      model_.command_active_ = false;
+    }
+
+    CommandScope(const CommandScope &) = delete;
+    CommandScope &operator=(const CommandScope &) = delete;
+
+  private:
+    RtCoreModel &model_;
+  };
+
+  uint64_t sm_generation_ = 1;
+  uint64_t traverse_issue_count_ = 0;
+  uint64_t release_issue_count_ = 0;
+  RtPrivateState private_state_;
+  bool command_active_ = false;
+};
+
+} // namespace ventus_rt
+
+#endif

--- a/tests/ventus_extra_stage2_static.py
+++ b/tests/ventus_extra_stage2_static.py
@@ -51,12 +51,16 @@ def main() -> int:
            if (ROOT / "riscv" / "ventus_mma.h").exists() else "")
         + ((ROOT / "riscv" / "ventus_rt.h").read_text(encoding="utf-8")
            if (ROOT / "riscv" / "ventus_rt.h").exists() else "")
+        + ((ROOT / "riscv" / "ventus_rtcore_model.h").read_text(encoding="utf-8")
+           if (ROOT / "riscv" / "ventus_rtcore_model.h").exists() else "")
     )
 
     require("0x0a ? 4" in decode or "0x0a ||" in decode,
             "insn_length does not force opcode 0x0a to 32 bits", failures)
     require("ventus_mma.h" in riscv_mk, "ventus_mma.h missing from riscv headers", failures)
     require("ventus_rt.h" in riscv_mk, "ventus_rt.h missing from riscv headers", failures)
+    require("ventus_rtcore_model.h" in riscv_mk,
+            "ventus_rtcore_model.h missing from riscv headers", failures)
     require("tests/ventus_rt_semantics.cc" in "\n".join(
             str(path.relative_to(ROOT)) for path in (ROOT / "tests").glob("*")),
             "ventus_rt_semantics.cc missing", failures)
@@ -66,6 +70,12 @@ def main() -> int:
             "ventus_exec_rt_traverse declaration/definition missing", failures)
     require("void ventus_exec_rt_release(processor_t *p, insn_t insn)" in custom,
             "ventus_exec_rt_release declaration/definition missing", failures)
+    require("executeLegacyTraverse" in custom,
+            "RT traverse instruction does not enter the warp RTCore model", failures)
+    require("executeLegacyRelease" in custom,
+            "RT release instruction does not enter the warp RTCore model", failures)
+    require("class LegacyPdsAdapter" in custom,
+            "named legacy PDS adapter boundary missing", failures)
 
     for insn, disasm_name, match, mask in MMA:
         macro = insn.upper()
@@ -156,8 +166,10 @@ def main() -> int:
         "trace_triangle_list",
         "trace_aabb_list",
         "make_hybrid_memory",
-        "ventus_rt::traverse(mem, slot)",
-        "ventus_rt::release(mem, slot)",
+        "ventus_rt::traverse(memory, issue.lane_slots[lane], private_state)",
+        "ventus_rt::release(memory, issue.lane_slots[lane], private_state)",
+        "RtPrivateState private_state_",
+        "private_state_.reset()",
     ]:
         require(symbol in custom, f"local RT model symbol missing: {symbol}", failures)
 

--- a/tests/ventus_rt_semantics.cc
+++ b/tests/ventus_rt_semantics.cc
@@ -1,5 +1,5 @@
 #define VENTUS_RT_STANDALONE
-#include "ventus_rt.h"
+#include "ventus_rtcore_model.h"
 
 #include <cassert>
 #include <cmath>
@@ -10,6 +10,13 @@ using namespace ventus_rt;
 
 struct TestMemory {
   std::unordered_map<reg_t, uint32_t> words;
+  uint64_t context_id = next_context_id++;
+  static uint64_t next_context_id;
+
+  uint64_t rt_context_key(reg_t slot) const
+  {
+    return (context_id << 32) ^ slot;
+  }
 
   uint32_t load32(reg_t addr)
   {
@@ -20,6 +27,27 @@ struct TestMemory {
   void store32(reg_t addr, uint32_t value)
   {
     words[addr] = value;
+  }
+};
+
+uint64_t TestMemory::next_context_id = 1;
+
+struct TestMemoryProxy {
+  TestMemory &memory;
+
+  uint64_t rt_context_key(reg_t slot) const
+  {
+    return memory.rt_context_key(slot);
+  }
+
+  uint32_t load32(reg_t addr)
+  {
+    return memory.load32(addr);
+  }
+
+  void store32(reg_t addr, uint32_t value)
+  {
+    memory.store32(addr, value);
   }
 };
 
@@ -271,6 +299,34 @@ static void check_closest_hit_wins()
                    hit_record_primitive_id) == 2);
 }
 
+static void check_candidate_replaces_farther_opaque_hit()
+{
+  TestMemory mem;
+  constexpr reg_t slot = 0;
+  constexpr reg_t accel = 0x13200;
+  constexpr reg_t tris = 0x13300;
+
+  write_scene(mem, accel, tris, 2);
+  write_triangle(mem, tris, 7.0f, 41, 0, 1);
+  write_triangle(mem, tris + 80, 3.0f, 42, 0, 0);
+  write_ray(mem, slot, accel);
+
+  assert(traverse(mem, slot) == traversal_candidate_non_opaque_triangle);
+  assert(load_slot(mem, slot, committed_hit_record_base,
+                   hit_record_primitive_id) == 41);
+  assert(load_slot(mem, slot, candidate_hit_record_base,
+                   hit_record_primitive_id) == 42);
+
+  store_slot(mem, slot, control_base, control_accept_hit, 1);
+  assert(traverse(mem, slot) == traversal_complete_hit);
+  assert(load_slot(mem, slot, committed_hit_record_base,
+                   hit_record_primitive_id) == 42);
+  assert(std::fabs(bit_cast_f32(load_slot(mem, slot,
+                                          committed_hit_record_base,
+                                          hit_record_hit_t)) -
+                   3.0f) < 0.001f);
+}
+
 static void check_non_opaque_candidate_accept_and_ignore()
 {
   {
@@ -327,6 +383,7 @@ static void check_non_opaque_candidate_accept_and_ignore()
     assert(traverse(mem, slot) == traversal_candidate_non_opaque_triangle);
     assert(load_slot(mem, slot, candidate_hit_record_base,
                      hit_record_primitive_id) == 10);
+    release(mem, slot);
   }
 
   {
@@ -358,7 +415,13 @@ static void check_terminate_and_release()
 {
   TestMemory mem;
   constexpr reg_t slot = 0;
+  constexpr reg_t accel = 0x22000;
+  constexpr reg_t tris = 0x23000;
 
+  write_scene(mem, accel, tris, 1);
+  write_triangle(mem, tris, 2.0f, 31, 0, 0);
+  write_ray(mem, slot, accel);
+  assert(traverse(mem, slot) == traversal_candidate_non_opaque_triangle);
   store_slot(mem, slot, control_base, control_terminate_ray, 1);
   assert(traverse(mem, slot) == traversal_terminated);
   assert(load_slot(mem, slot, control_base, control_done) == 1);
@@ -370,6 +433,27 @@ static void check_terminate_and_release()
   release(mem, slot);
   assert(load_slot(mem, slot, control_base, control_done) == 0);
   assert(load_slot(mem, slot, control_base, control_terminate_ray) == 0);
+}
+
+static void check_accept_and_terminate_completes_hit()
+{
+  TestMemory mem;
+  constexpr reg_t slot = 0;
+  constexpr reg_t accel = 0x26000;
+  constexpr reg_t tris = 0x27000;
+
+  write_scene(mem, accel, tris, 1);
+  write_triangle(mem, tris, 2.0f, 32, 0, 0);
+  write_ray(mem, slot, accel);
+  assert(traverse(mem, slot) == traversal_candidate_non_opaque_triangle);
+
+  store_slot(mem, slot, control_base, control_accept_hit, 1);
+  store_slot(mem, slot, control_base, control_terminate_ray, 1);
+  assert(traverse(mem, slot) == traversal_complete_hit);
+  assert(load_slot(mem, slot, 0, slot_status) == rt_status_hit);
+  assert(load_slot(mem, slot, control_base, control_done) == 1);
+  assert(load_slot(mem, slot, committed_hit_record_base,
+                   hit_record_primitive_id) == 32);
 }
 
 static void check_procedural_candidate_report_accept()
@@ -453,15 +537,132 @@ static void check_pds_formula()
   assert(mem.load32(physical) == 0xabcdef01);
 }
 
+static void check_rt_private_context_abi()
+{
+  TestMemory mem;
+  constexpr reg_t slot = 0;
+  constexpr reg_t accel = 0x24000;
+  constexpr reg_t tris = 0x25000;
+
+  write_scene(mem, accel, tris, 1);
+  write_triangle(mem, tris, 2.0f, 41, 0, 0);
+  write_ray(mem, slot, accel);
+  assert(traverse(mem, slot) == traversal_candidate_non_opaque_triangle);
+  store_slot(mem, slot, control_base, control_ignore_hit, 1);
+  assert(traverse(mem, slot) == traversal_complete_miss);
+
+  assert(rt_region_size_bytes == 384);
+  assert(cps_header_base == 96);
+  assert(control_base == 112);
+  assert(candidate_hit_record_base == 144);
+  assert(committed_hit_record_base == 224);
+  assert(hit_attrib_base == 304);
+  for (const auto &word : mem.words)
+    assert(word.first < rt_region_size_bytes || word.first >= accel);
+}
+
+static void check_rtcore_legacy_warp_boundary()
+{
+  TestMemory mem;
+  constexpr reg_t hit_slot = 0x0000;
+  constexpr reg_t miss_slot = 0x1000;
+  constexpr reg_t accel = 0x10000;
+  constexpr reg_t tris = 0x11000;
+
+  write_scene(mem, accel, tris, 1);
+  write_triangle(mem, tris, 5.0f, 42, 4, 1);
+  write_ray(mem, hit_slot, accel);
+  write_ray(mem, miss_slot, accel);
+  store_slot(mem, miss_slot, 0, slot_origin_x, bit_cast_u32(4.0f));
+
+  RtCoreModel model;
+  LegacyWarpIssue issue;
+  issue.active_mask = (uint32_t{1} << 0) | (uint32_t{1} << 2);
+  issue.first_lane = 0;
+  issue.lane_count = 4;
+  issue.lane_slots[0] = hit_slot;
+  issue.lane_slots[2] = miss_slot;
+
+  const LegacyWarpResult result = model.executeLegacyTraverse(
+      issue, [&mem](uint32_t) { return TestMemoryProxy{mem}; });
+  assert(result.valid_mask == issue.active_mask);
+  assert(result.lane_status[0] == traversal_complete_hit);
+  assert(result.lane_status[2] == traversal_complete_miss);
+  assert((result.valid_mask & (uint32_t{1} << 1)) == 0);
+
+  RtCoreDebugSnapshot snapshot = model.debugSnapshot();
+  assert(snapshot.traverse_issue_count == 1);
+  assert(snapshot.release_issue_count == 0);
+  assert(snapshot.private_context_count == 0);
+  assert(!snapshot.command_active);
+
+  const uint32_t released_mask = model.executeLegacyRelease(
+      issue, [&mem](uint32_t) { return TestMemoryProxy{mem}; });
+  assert(released_mask == issue.active_mask);
+  assert(load_slot(mem, hit_slot, control_base, control_done) == 0);
+  assert(load_slot(mem, miss_slot, control_base, control_done) == 0);
+
+  snapshot = model.debugSnapshot();
+  assert(snapshot.traverse_issue_count == 1);
+  assert(snapshot.release_issue_count == 1);
+  assert(snapshot.private_context_count == 0);
+
+  constexpr reg_t candidate_slot = 0x2000;
+  constexpr reg_t candidate_accel = 0x12000;
+  constexpr reg_t candidate_tris = 0x13000;
+  write_scene(mem, candidate_accel, candidate_tris, 1);
+  write_triangle(mem, candidate_tris, 2.0f, 91, 0, 0);
+  write_ray(mem, candidate_slot, candidate_accel);
+
+  LegacyWarpIssue candidate_issue;
+  candidate_issue.active_mask = uint32_t{1} << 1;
+  candidate_issue.lane_count = 4;
+  candidate_issue.lane_slots[1] = candidate_slot;
+  const LegacyWarpResult candidate_result = model.executeLegacyTraverse(
+      candidate_issue, [&mem](uint32_t) { return TestMemoryProxy{mem}; });
+  assert(candidate_result.valid_mask == candidate_issue.active_mask);
+  assert(candidate_result.lane_status[1] ==
+         traversal_candidate_non_opaque_triangle);
+  snapshot = model.debugSnapshot();
+  assert(snapshot.private_context_count == 1);
+
+  model.executeLegacyRelease(
+      candidate_issue, [&mem](uint32_t) { return TestMemoryProxy{mem}; });
+  snapshot = model.debugSnapshot();
+  assert(snapshot.private_context_count == 0);
+  const uint64_t previous_generation = snapshot.sm_generation;
+
+  model.resetSm();
+  snapshot = model.debugSnapshot();
+  assert(snapshot.sm_generation == previous_generation + 1);
+  assert(snapshot.traverse_issue_count == 0);
+  assert(snapshot.release_issue_count == 0);
+  assert(snapshot.private_context_count == 0);
+
+  LegacyWarpIssue suffix_issue = issue;
+  suffix_issue.first_lane = 2;
+  const LegacyWarpResult suffix_result = model.executeLegacyTraverse(
+      suffix_issue, [&mem](uint32_t) { return TestMemoryProxy{mem}; });
+  assert(suffix_result.valid_mask == (uint32_t{1} << 2));
+  assert(suffix_result.lane_status[2] == traversal_complete_miss);
+  snapshot = model.debugSnapshot();
+  assert(snapshot.traverse_issue_count == 1);
+  assert(snapshot.release_issue_count == 0);
+}
+
 int main()
 {
   check_opaque_hit();
   check_miss();
   check_closest_hit_wins();
+  check_candidate_replaces_farther_opaque_hit();
   check_non_opaque_candidate_accept_and_ignore();
   check_terminate_and_release();
+  check_accept_and_terminate_completes_hit();
   check_procedural_candidate_report_accept();
   check_vtas_tlas_blas_triangle_hit();
   check_pds_formula();
+  check_rt_private_context_abi();
+  check_rtcore_legacy_warp_boundary();
   return 0;
 }


### PR DESCRIPTION
## Summary

- route `vt.rt.traverse` and `vt.rt.release` through a simulator-owned, warp-issued `RtCoreModel`
- preserve SIMT active-mask and per-lane status behavior through the legacy PDS adapter
- keep paused traversal cursor/frontier/stack in RTCore-private state instead of shader-visible scratch
- release private contexts on `vt.rt.release` and simulator reset
- make accept-plus-terminate complete as a hit when the accepted candidate is valid

## Validation

- `g++ -std=c++17 -Wall -Wextra -Werror -I riscv tests/ventus_rt_semantics.cc -o /tmp/ventus_rt_semantics_v2_pr`
- `/tmp/ventus_rt_semantics_v2_pr`
- `python3 tests/ventus_extra_stage2_static.py`
- `make -C build -j4`
- cross-repository exact-image gate: 160x96, 136 colors, SHA-256 `f43328945bdeb0dda69b3cc5612212170e5596456450184acfa627db8d5d1212`

## Scope

This is a functional Spike model. It currently maps all warps to one logical SM0 RTCore instance and does not model RTL timing, capacity, backpressure, or memory contention. The legacy PDS adapter remains the instruction boundary for the current compatibility profile.
